### PR TITLE
Fix double feedback issue for api integration.

### DIFF
--- a/robtex_python/cli.py
+++ b/robtex_python/cli.py
@@ -35,17 +35,21 @@ def main(arguments=None):
         pass
 
     if arguments.get('--ip'):
-        print(ip_query(arguments['--ip']))
-        return ip_query(arguments['--ip'])
+        output = ip_query(arguments['--ip'])
+        print(output)
+        return output
     elif arguments.get('--as'):
-        print(as_query(arguments['--as']))
-        return as_query(arguments['--as'])
+        output = as_query(arguments['--as'])
+        print(output)
+        return output
     elif arguments.get('--pdns-forward'):
-        print(pdns_forward(arguments['--pdns-forward']))
-        return pdns_forward(arguments['--pdns-forward'])
+        output = pdns_forward(arguments['--pdns-forward'])
+        print(output)
+        return output
     elif arguments.get('--pdns-reverse'):
-        print(pdns_reverse(arguments['--pdns-reverse']))
-        return pdns_reverse(arguments['--pdns-reverse'])
+        output = pdns_reverse(arguments['--pdns-reverse'])
+        print(output)
+        return output
 
 
 if __name__ == "__main__":

--- a/robtex_python/cli.py
+++ b/robtex_python/cli.py
@@ -35,13 +35,13 @@ def main(arguments=None):
         pass
 
     if arguments.get('--ip'):
-        return ip_query(arguments['--ip'])
+        print(ip_query(arguments['--ip']))
     elif arguments.get('--as'):
-        return as_query(arguments['--as'])
+        print(as_query(arguments['--as']))
     elif arguments.get('--pdns-forward'):
-        return pdns_forward(arguments['--pdns-forward'])
+        print(pdns_forward(arguments['--pdns-forward']))
     elif arguments.get('--pdns-reverse'):
-        return pdns_reverse(arguments['--pdns-reverse'])
+        print(pdns_reverse(arguments['--pdns-reverse']))
 
 
 if __name__ == "__main__":

--- a/robtex_python/cli.py
+++ b/robtex_python/cli.py
@@ -36,12 +36,16 @@ def main(arguments=None):
 
     if arguments.get('--ip'):
         print(ip_query(arguments['--ip']))
+        return ip_query(arguments['--ip'])
     elif arguments.get('--as'):
         print(as_query(arguments['--as']))
+        return as_query(arguments['--as'])
     elif arguments.get('--pdns-forward'):
         print(pdns_forward(arguments['--pdns-forward']))
+        return pdns_forward(arguments['--pdns-forward'])
     elif arguments.get('--pdns-reverse'):
         print(pdns_reverse(arguments['--pdns-reverse']))
+        return pdns_reverse(arguments['--pdns-reverse'])
 
 
 if __name__ == "__main__":

--- a/robtex_python/robtex_python.py
+++ b/robtex_python/robtex_python.py
@@ -10,27 +10,22 @@ BASE_API_URL = "https://freeapi.robtex.com/"
 def ip_query(ip_address):
     """Get the current forward and reverse of an IP number, together with GEO-location data and network data."""
     response = get(BASE_API_URL + "ipquery/{}".format(ip_address))
-    print(response)
     return response
 
 
 def as_query(as_number):
     """Get the networks actually in global bgp table (plans to expand this in the future)."""
     response = get(BASE_API_URL + "asquery/{}".format(as_number))
-    print(response)
     return response
 
 
 def pdns_forward(hostname):
     """Get the IP addresses to which the given host has resolved."""
     response = get(BASE_API_URL + "pdns/forward/{}".format(hostname))
-    print(response)
     return response
 
 
 def pdns_reverse(ip_address):
     """Get the reverse pdns for the given IP address."""
-    response = get(BASE_API_URL +
-                             "pdns/reverse/{}".format(ip_address))
-    print(response)
+    response = get(BASE_API_URL + "pdns/reverse/{}".format(ip_address))
     return response


### PR DESCRIPTION
I removed the print statements from the API functions. This was an oddity when I was using your wrapper.

For example, doing something like this would cause the results to print to the screen unnecessarily:
```python
from robtex_python import robtex_python

response = robtex_python.pdns_forward('https://github.com/')
```

And doing something like this would cause the results to be printed twice:
```python
from robtex_python import robtex_python

response = robtex_python.pdns_forward('https://github.com/')
print(response)
```

I'm integrating your wrapper into a tool I'm building, thanks for your work on this.